### PR TITLE
Speedups, header values and distortion maps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 * Fix star brightness, speed up polarized starfield, and other optimizations in https://github.com/punch-mission/simpunch/pull/117
 * Improves documentation in https://github.com/punch-mission/simpunch/pull/113
 * Match metadata changes in punchbowl in https://github.com/punch-mission/simpunch/pull/120
+* Remove distortion maps from polarized L1s, use header parameters for msb_to_dn and compute_noise, adds bias to images, and small speedups in https://github.com/punch-mission/simpunch/pull/121
 
 ## Version 0.0.3: Dec 19, 2024
 

--- a/simpunch/flow.py
+++ b/simpunch/flow.py
@@ -1,6 +1,6 @@
 """Run the entire pipeline backward."""
 import os
-from typing import Callable
+from collections.abc import Callable
 from datetime import datetime, timedelta
 
 import numpy as np

--- a/simpunch/flow.py
+++ b/simpunch/flow.py
@@ -27,10 +27,14 @@ def generate_flow(file_tb: str,
     rotation_indices = np.array([0, 0, 1, 1, 2, 2, 3, 3])
     rotation_stage: int = rotation_indices[i % 8]
 
-    l3_ptm = generate_l3_ptm(file_tb, file_pb, out_dir, time_obs, timedelta(minutes=4), rotation_stage)
-    l3_ctm = generate_l3_ctm(file_tb, out_dir, time_obs, timedelta(minutes=4), rotation_stage)
-    l2_ptm = generate_l2_ptm(l3_ptm, out_dir)
-    l2_ctm = generate_l2_ctm(l3_ctm, out_dir)
+    l3_ptm = generate_l3_ptm.submit(file_tb, file_pb, out_dir, time_obs, timedelta(minutes=4), rotation_stage)
+    l3_ctm = generate_l3_ctm.submit(file_tb, out_dir, time_obs, timedelta(minutes=4), rotation_stage)
+    l3_ptm = l3_ptm.result()
+    l3_ctm = l3_ctm.result()
+    l2_ptm = generate_l2_ptm.submit(l3_ptm, out_dir)
+    l2_ctm = generate_l2_ctm.submit(l3_ctm, out_dir)
+    l2_ptm = l2_ptm.result()
+    l2_ctm = l2_ctm.result()
 
     l1_polarized = []
     l1_clear = []
@@ -46,13 +50,13 @@ def generate_flow(file_tb: str,
         l0_pmzp.append(generate_l0_pmzp.submit(filename, out_dir, backward_psf_model_path,  # noqa: PERF401
                                                wfi_quartic_backward_model_path, nfi_quartic_backward_model_path,
                                                    transient_probability, shift_pointing))
-    l0_pmzp = [entry.result() for entry in l0_pmzp]
 
     l0_cr = []
     for filename in l1_clear:
         l0_cr.append(generate_l0_cr.submit(filename, out_dir, backward_psf_model_path,  # noqa: PERF401
                                                wfi_quartic_backward_model_path, nfi_quartic_backward_model_path,
                                                transient_probability, shift_pointing))
+    l0_pmzp = [entry.result() for entry in l0_pmzp]
     l0_cr = [entry.result() for entry in l0_cr]
 
     return [l3_ptm, l3_ctm, l2_ptm, l2_ctm] + l1_polarized + l1_clear + l0_pmzp + l0_cr  # noqa: RUF005

--- a/simpunch/flow.py
+++ b/simpunch/flow.py
@@ -1,5 +1,6 @@
 """Run the entire pipeline backward."""
 import os
+from typing import Callable
 from datetime import datetime, timedelta
 
 import numpy as np
@@ -17,9 +18,9 @@ def generate_flow(file_tb: str,
                   file_pb: str,
                   time_obs: datetime,
                   out_dir: str,
-                  backward_psf_model_path: str,
-                  wfi_quartic_backward_model_path: str,
-                  nfi_quartic_backward_model_path: str,
+                  backward_psf_model_path: str | Callable,
+                  wfi_quartic_backward_model_path: str | Callable,
+                  nfi_quartic_backward_model_path: str | Callable,
                   transient_probability: float = 0.03,
                   shift_pointing: bool = False) -> list[str]:
     """Generate all the products in the reverse pipeline."""

--- a/simpunch/flow.py
+++ b/simpunch/flow.py
@@ -12,7 +12,7 @@ from simpunch.level2 import generate_l2_ctm, generate_l2_ptm
 from simpunch.level3 import generate_l3_ctm, generate_l3_ptm
 
 
-@flow(task_runner=DaskTaskRunner())
+@flow(task_runner=DaskTaskRunner(address="localhost:8786"))
 def generate_flow(file_tb: str,
                   file_pb: str,
                   time_obs: datetime,

--- a/simpunch/level0.py
+++ b/simpunch/level0.py
@@ -190,21 +190,23 @@ def generate_l0_pmzp(input_file: str,
     logger.info("Photometry scrambled")
 
     if input_data.meta["OBSCODE"].value == "4":
-        scaling = {"gain": 4.9 * u.photon / u.DN,
+        scaling = {"gain_left": input_data.meta['GAINLEFT'].value * u.photon / u.DN,
+                   "gain_right": input_data.meta['GAINRGHT'].value * u.photon / u.DN,
                    "wavelength": 530. * u.nm,
-                   "exposure": 49 * u.s,
+                   "exposure": input_data.meta['EXPTIME'].value * u.s,
                    "aperture": 49.57 * u.mm ** 2}
     else:
-        scaling = {"gain": 4.9 * u.photon / u.DN,
+        scaling = {"gain_left": input_data.meta['GAINLEFT'].value * u.photon / u.DN,
+                   "gain_right": input_data.meta['GAINRGHT'].value * u.photon / u.DN,
                    "wavelength": 530. * u.nm,
-                   "exposure": 49 * u.s,
+                   "exposure": input_data.meta['EXPTIME'].value * u.s,
                    "aperture": 34 * u.mm ** 2}
     output_data.data[:, :] = msb_to_dn(
         output_data.data[:, :], output_data.wcs, **scaling, pixel_area_stride=3)
     logger.info("Units scaled")
 
-    noise = compute_noise(output_data.data)
-    output_data.data[...] += noise[...]
+    data, noise = compute_noise(output_data.data, bias_level=output_data.meta['OFFSET'].value)
+    output_data.data[...] = data + noise
     logger.info("Noise added")
 
     output_data, spike_image = add_spikes(output_data)
@@ -314,21 +316,23 @@ def generate_l0_cr(input_file: str, path_output: str,
     logger.info("Photometry scrambled")
 
     if input_data.meta["OBSCODE"].value == "4":
-        scaling = {"gain": 4.9 * u.photon / u.DN,
+        scaling = {"gain_left": input_data.meta['GAINLEFT'].value * u.photon / u.DN,
+                   "gain_right": input_data.meta['GAINRGHT'].value * u.photon / u.DN,
                    "wavelength": 530. * u.nm,
-                   "exposure": 49 * u.s,
+                   "exposure": input_data.meta['EXPTIME'].value * u.s,
                    "aperture": 49.57 * u.mm ** 2}
     else:
-        scaling = {"gain": 4.9 * u.photon / u.DN,
+        scaling = {"gain_left": input_data.meta['GAINLEFT'].value * u.photon / u.DN,
+                   "gain_right": input_data.meta['GAINRGHT'].value * u.photon / u.DN,
                    "wavelength": 530. * u.nm,
-                   "exposure": 49 * u.s,
+                   "exposure": input_data.meta['EXPTIME'].value * u.s,
                    "aperture": 34 * u.mm ** 2}
     output_data.data[:, :] = msb_to_dn(
         output_data.data[:, :], output_data.wcs, **scaling, pixel_area_stride=3)
     logger.info("Units scaled")
 
-    noise = compute_noise(output_data.data)
-    output_data.data[...] += noise[...]
+    data, noise = compute_noise(output_data.data, bias_level=output_data.meta['OFFSET'].value)
+    output_data.data[...] = data + noise
     logger.info("Noise added")
 
     output_data, spike_image = add_spikes(output_data)

--- a/simpunch/level0.py
+++ b/simpunch/level0.py
@@ -1,13 +1,11 @@
 """Generate synthetic level 0 data."""
 import copy
 import os
-import warnings
+from collections.abc import Callable
 from pathlib import Path
 from random import random
-from typing import Callable
 
 import astropy.units as u
-import astropy.wcs
 import numpy as np
 from ndcube import NDCube
 from prefect import get_run_logger, task
@@ -198,22 +196,22 @@ def generate_l0_pmzp(input_file: str,
     logger.info("Photometry scrambled")
 
     if input_data.meta["OBSCODE"].value == "4":
-        scaling = {"gain_left": input_data.meta['GAINLEFT'].value * u.photon / u.DN,
-                   "gain_right": input_data.meta['GAINRGHT'].value * u.photon / u.DN,
+        scaling = {"gain_left": input_data.meta["GAINLEFT"].value * u.photon / u.DN,
+                   "gain_right": input_data.meta["GAINRGHT"].value * u.photon / u.DN,
                    "wavelength": 530. * u.nm,
-                   "exposure": input_data.meta['EXPTIME'].value * u.s,
+                   "exposure": input_data.meta["EXPTIME"].value * u.s,
                    "aperture": 49.57 * u.mm ** 2}
     else:
-        scaling = {"gain_left": input_data.meta['GAINLEFT'].value * u.photon / u.DN,
-                   "gain_right": input_data.meta['GAINRGHT'].value * u.photon / u.DN,
+        scaling = {"gain_left": input_data.meta["GAINLEFT"].value * u.photon / u.DN,
+                   "gain_right": input_data.meta["GAINRGHT"].value * u.photon / u.DN,
                    "wavelength": 530. * u.nm,
-                   "exposure": input_data.meta['EXPTIME'].value * u.s,
+                   "exposure": input_data.meta["EXPTIME"].value * u.s,
                    "aperture": 34 * u.mm ** 2}
     output_data.data[:, :] = msb_to_dn(
         output_data.data[:, :], output_data.wcs, **scaling, pixel_area_stride=3)
     logger.info("Units scaled")
 
-    data, noise = compute_noise(output_data.data, bias_level=output_data.meta['OFFSET'].value)
+    data, noise = compute_noise(output_data.data, bias_level=output_data.meta["OFFSET"].value)
     output_data.data[...] = data + noise
     logger.info("Noise added")
 
@@ -326,22 +324,22 @@ def generate_l0_cr(input_file: str, path_output: str,
     logger.info("Photometry scrambled")
 
     if input_data.meta["OBSCODE"].value == "4":
-        scaling = {"gain_left": input_data.meta['GAINLEFT'].value * u.photon / u.DN,
-                   "gain_right": input_data.meta['GAINRGHT'].value * u.photon / u.DN,
+        scaling = {"gain_left": input_data.meta["GAINLEFT"].value * u.photon / u.DN,
+                   "gain_right": input_data.meta["GAINRGHT"].value * u.photon / u.DN,
                    "wavelength": 530. * u.nm,
-                   "exposure": input_data.meta['EXPTIME'].value * u.s,
+                   "exposure": input_data.meta["EXPTIME"].value * u.s,
                    "aperture": 49.57 * u.mm ** 2}
     else:
-        scaling = {"gain_left": input_data.meta['GAINLEFT'].value * u.photon / u.DN,
-                   "gain_right": input_data.meta['GAINRGHT'].value * u.photon / u.DN,
+        scaling = {"gain_left": input_data.meta["GAINLEFT"].value * u.photon / u.DN,
+                   "gain_right": input_data.meta["GAINRGHT"].value * u.photon / u.DN,
                    "wavelength": 530. * u.nm,
-                   "exposure": input_data.meta['EXPTIME'].value * u.s,
+                   "exposure": input_data.meta["EXPTIME"].value * u.s,
                    "aperture": 34 * u.mm ** 2}
     output_data.data[:, :] = msb_to_dn(
         output_data.data[:, :], output_data.wcs, **scaling, pixel_area_stride=3)
     logger.info("Units scaled")
 
-    data, noise = compute_noise(output_data.data, bias_level=output_data.meta['OFFSET'].value)
+    data, noise = compute_noise(output_data.data, bias_level=output_data.meta["OFFSET"].value)
     output_data.data[...] = data + noise
     logger.info("Noise added")
 

--- a/simpunch/level0.py
+++ b/simpunch/level0.py
@@ -28,9 +28,9 @@ def perform_photometric_uncalibration(input_data: NDCube, coefficient_array: np.
     """Undo quartic fit calibration."""
     num_coefficients = coefficient_array.shape[0]
     new_data = np.nansum(
-        [coefficient_array[i, ...] * np.power(input_data.data, num_coefficients - i - 1)
+        [coefficient_array[i] * np.power(input_data.data, num_coefficients - i - 1)
          for i in range(num_coefficients)], axis=0)
-    input_data.data[...] = new_data[...]
+    input_data.data[...] = new_data
     return input_data
 
 
@@ -59,7 +59,7 @@ def apply_streaks(input_data: NDCube,
     """Apply the streak matrix to the image."""
     streak_matrix = create_streak_matrix(input_data.data.shape[0],
                                          exposure_time, readout_line_time, reset_line_time)
-    input_data.data[:, :] = streak_matrix @ input_data.data[:, :] / exposure_time
+    input_data.data[:, :] = streak_matrix @ input_data.data / exposure_time
     return input_data
 
 
@@ -79,7 +79,7 @@ def add_stray_light(input_data: NDCube,
 
 def uncorrect_psf(input_data: NDCube, psf_model: ArrayPSFTransform) -> NDCube:
     """Apply an inverse PSF to an image."""
-    input_data.data[...] = psf_model.apply(input_data.data)[...]
+    input_data.data[...] = psf_model.apply(input_data.data)
     return input_data
 
 

--- a/simpunch/level0.py
+++ b/simpunch/level0.py
@@ -73,7 +73,7 @@ def add_stray_light(input_data: NDCube,
                     polar: str = "mzp") -> NDCube:
     """Add stray light to the image."""
     straydata = generate_stray_light(input_data.data.shape, instrument=inst, pstate="pb" if polar == "mzp" else "b")
-    input_data.data[:, :] = input_data.data[:, :] + straydata
+    input_data.data[:, :] += straydata
     return input_data
 
 

--- a/simpunch/level0.py
+++ b/simpunch/level0.py
@@ -18,6 +18,7 @@ from punchbowl.data.wcs import calculate_pc_matrix, extract_crota_from_wcs
 from punchbowl.level1.initial_uncertainty import compute_noise
 from punchbowl.level1.sqrt import encode_sqrt
 from regularizepsf import ArrayPSFTransform
+from threadpoolctl import threadpool_limits
 
 from simpunch.spike import generate_spike_image
 from simpunch.util import (fill_metadata_defaults, generate_stray_light,
@@ -60,7 +61,8 @@ def apply_streaks(input_data: NDCube,
     """Apply the streak matrix to the image."""
     streak_matrix = create_streak_matrix(input_data.data.shape[0],
                                          exposure_time, readout_line_time, reset_line_time)
-    input_data.data[:, :] = streak_matrix @ input_data.data / exposure_time
+    with threadpool_limits(4):
+        input_data.data[:, :] = streak_matrix @ input_data.data / exposure_time
     return input_data
 
 

--- a/simpunch/level1.py
+++ b/simpunch/level1.py
@@ -434,10 +434,10 @@ def generate_l1_pmzp(input_file: str, path_output: str, rotation_stage: int, spa
     output_pdata.meta["POLAR"] = 60
 
     # Add distortion
-    # output_mdata = add_distortion(output_mdata)
-    # output_zdata = add_distortion(output_zdata)
-    # output_pdata = add_distortion(output_pdata)
-    # logger.info("Distortion added")
+    # output_mdata = add_distortion(output_mdata)  # noqa: ERA001
+    # output_zdata = add_distortion(output_zdata)  # noqa: ERA001
+    # output_pdata = add_distortion(output_pdata)  # noqa: ERA001
+    # logger.info("Distortion added")  # noqa: ERA001
 
     output_collection = NDCollection(
         [("M", output_mdata),

--- a/simpunch/level1.py
+++ b/simpunch/level1.py
@@ -434,10 +434,10 @@ def generate_l1_pmzp(input_file: str, path_output: str, rotation_stage: int, spa
     output_pdata.meta["POLAR"] = 60
 
     # Add distortion
-    output_mdata = add_distortion(output_mdata)
-    output_zdata = add_distortion(output_zdata)
-    output_pdata = add_distortion(output_pdata)
-    logger.info("Distortion added")
+    # output_mdata = add_distortion(output_mdata)
+    # output_zdata = add_distortion(output_zdata)
+    # output_pdata = add_distortion(output_pdata)
+    # logger.info("Distortion added")
 
     output_collection = NDCollection(
         [("M", output_mdata),

--- a/simpunch/level2.py
+++ b/simpunch/level2.py
@@ -35,7 +35,6 @@ def generate_fcorona(shape: (int, int),
                      b: float = 300.,
                      tilt_offset: tuple[float] = (0, 0)) -> np.ndarray:
     """Generate an F corona model."""
-    fcorona = np.zeros(shape)
 
     if len(shape) > 2:  # noqa: PLR2004
         xdim = 1
@@ -66,13 +65,7 @@ def generate_fcorona(shape: (int, int),
 
     fcorona_profile = fcorona_profile / fcorona_profile.max() * 1e-12
 
-    if len(shape) > 2:  # noqa: PLR2004
-        for i in np.arange(fcorona.shape[0]):
-            fcorona[i, :, :] = fcorona_profile[:, :]
-    else:
-        fcorona[:, :] = fcorona_profile[:, :]
-
-    return fcorona
+    return fcorona_profile
 
 
 def add_fcorona(input_data: NDCube) -> NDCube:
@@ -81,9 +74,10 @@ def add_fcorona(input_data: NDCube) -> NDCube:
 
     fcorona = generate_fcorona(input_data.data.shape, **fcorona_parameters)
 
-    fcorona = fcorona * (input_data.data != 0)
+    fcorona *= input_data.data != 0
 
-    input_data.data[...] = input_data.data[...] + fcorona
+    # For the polarized (3D array) case, this 2D F corona will broadcast to the right shape
+    input_data.data[...] += fcorona
 
     return input_data
 

--- a/simpunch/level2.py
+++ b/simpunch/level2.py
@@ -35,7 +35,6 @@ def generate_fcorona(shape: (int, int),
                      b: float = 300.,
                      tilt_offset: tuple[float] = (0, 0)) -> np.ndarray:
     """Generate an F corona model."""
-
     if len(shape) > 2:  # noqa: PLR2004
         xdim = 1
         ydim = 2

--- a/simpunch/level2.py
+++ b/simpunch/level2.py
@@ -62,9 +62,7 @@ def generate_fcorona(shape: (int, int),
     max_distance = 1
     fcorona_profile = np.exp(-superellipse ** 2 / (2 * max_distance ** 2))
 
-    fcorona_profile = fcorona_profile / fcorona_profile.max() * 1e-12
-
-    return fcorona_profile
+    return fcorona_profile / fcorona_profile.max() * 1e-12
 
 
 def add_fcorona(input_data: NDCube) -> NDCube:


### PR DESCRIPTION
- Mixed small speedups
- Pass values from the header to `msb_to_dn` and `compute_noise`
- Don't add a distortion map to polarized L1s---it's in between the reprojection and the starfield addition, meaning those two components aren't at consistent locations. For the clears this was already commented out.
- With change in simpunch, ensures bias is added to images